### PR TITLE
Query fields

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ sentry-sdk==1.17.0
 six==1.16.0
 urllib3==1.26.15
 minio==7.1.14
+pyarrow==11.0.0

--- a/trip/duckdata.py
+++ b/trip/duckdata.py
@@ -48,10 +48,10 @@ class DuckData():
     file = f'yellow_tripdata_2022-{now.month:02d}'
     query = f"""
         SELECT
-          tpep_pickup_datetime,
-          tpep_dropoff_datetime,
-          PULocationID,
-          DOLocationID,
+          strftime(tpep_pickup_datetime, '%Y-%m-%d %H:%M:%S') as pickup_datetime,
+          strftime(tpep_dropoff_datetime, '%Y-%m-%d %H:%M:%S') as dropoff_datetime,
+          PULocationID as pickup_location_id,
+          DOLocationID as dropoff_location_id,
           passenger_count,
           trip_distance,          
           payment_type,
@@ -87,6 +87,6 @@ class DuckData():
     sql = query.replace('PARQUET', parquet)
 
     try:
-      return self.connection.sql(sql).df()
+      return self.connection.sql(sql).fetch_arrow_table().to_pylist()
     except Exception as e:
       raise DuckDataException(e)

--- a/trip/producer.py
+++ b/trip/producer.py
@@ -34,15 +34,11 @@ class TripProducer:
     Publish trip events to Kafka.
     """
     now = datetime.now(timezone('US/Eastern'))
-    results = self.duckdata.get_trips(now)
-
-    columns = {'tpep_pickup_datetime': 'str', 'tpep_dropoff_datetime': 'str'}
-    records = results.astype(columns).to_dict(orient = 'records')
+    records = self.duckdata.get_trips(now)
 
     for record in records:
       try:
         self.producer.send('trips', record)
       except Exception as e:
         raise TripProducerException(f"Failed sending message to Kafka: {e}")
-
 


### PR DESCRIPTION
Include useful query fields in parquet query. Refactor to eliminate encoding NaNs in JSON.