### PR TITLE
Smooth out send times

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,6 +1,5 @@
 from trip.producer import TripProducer
 import sentry_sdk
-from time import sleep
 
 sentry_sdk.init(
   dsn = "https://d2ac4e11398b4f1ba34ae288fd866874@sentry.cauchy.link/3",
@@ -12,4 +11,3 @@ producer = TripProducer()
 if __name__ == "__main__":
   while True:
     producer.send()
-    sleep(1)

--- a/trip/producer.py
+++ b/trip/producer.py
@@ -3,6 +3,7 @@ from trip.duckdata import DuckData
 from datetime import datetime
 from pytz import timezone
 from json import dumps
+from time import sleep
 
 BOOTSTRAP_SERVER = "kafka-service.kafka.svc.cluster.local:9092"
 
@@ -36,7 +37,11 @@ class TripProducer:
     now = datetime.now(timezone('US/Eastern'))
     records = self.duckdata.get_trips(now)
 
+    if len(records) == 0:
+      sleep(1)
+
     for record in records:
+      sleep(1 / len(records))
       try:
         self.producer.send('trips', record)
       except Exception as e:


### PR DESCRIPTION
Smooth out send times by sleeping for a fraction of a second between pushing trip events to Kafka.